### PR TITLE
Array function

### DIFF
--- a/src/weeks.jl
+++ b/src/weeks.jl
@@ -15,12 +15,12 @@ mutable struct Weeks{T} <: AbstractWeeks
     Nterms::Int
     sigma::Float64
     b::Float64
-    coefficients::Array{T,1}
+    coefficients::Array{T,2}
 end
 
 function _get_coefficients(func, Nterms, sigma, b, ::Type{T}) where T <:Number
     a0 = _wcoeff(func, Nterms, sigma, b, T)
-    return a0[Nterms+1:2*Nterms]
+    return a0[Nterms+1:2*Nterms,:]
 end
 
 _get_coefficients(w::Weeks{T}) where T <: Number =  _get_coefficients(w.func, w.Nterms, w.sigma, w.b, T)
@@ -229,9 +229,15 @@ function _wcoeff(F, N, sig, b)
     s = sig .+ imaginary_unit * y
     FF0 = map(F, s)
     FF = [FF1 * (b + imaginary_unit * y1) for (FF1,y1) in zip(FF0,y)]
-    a = (FF |> AbstractFFTs.fftshift |> FFTW.fft |> AbstractFFTs.fftshift) / (2 * N)
-    return exp.(Complex(zero(h),-one(h)) * n*h/2) .* a
+    FFTranspose = Array{Complex{Float64},2}(undef,(length(y),2))
+    transpose!(FFTranspose,reshape(vcat(FF...),(2,length(y))))
+    FFp = FFTW.plan_fft!(FFTranspose,1,flags=FFTW.MEASURE)
+    a = colFFTwshift(FFp,FFTranspose) / (2 * N)
+    return exp.(Complex(zero(h),-one(h)) * n*h/2)  .* a
 end
+
+
+
 
 function _laguerre(a::AbstractVector,x::AbstractArray)
     N = length(a) - 1
@@ -247,13 +253,15 @@ function _laguerre(a::AbstractVector,x::AbstractArray)
     return unm1
 end
 
-function _laguerre(a::AbstractVector,x)
-    n = length(a) - 1
+
+
+function _laguerre(a::AbstractArray,x)
+    n = size(a)[1] - 1
     unp1 = zero(x)
-    un = a[n+1]*one(x)
+    un = a[n+1,:] .* one(x)
     local unm1
     for n in n:-1:1
-        unm1 = (1//n)*(2*n-1-x) * un - n/(n+1)*unp1 + a[n]
+        unm1 = (1//n)*(2*n-1-x) .* un .- n/(n+1)*unp1 + a[n,:]
         unp1 = un
         un = unm1
     end
@@ -282,4 +290,18 @@ function _werr2t(b, F, N, sig)
     a = _wcoeff(F,M,sig,b)
     sa2 = sum(abs.(@view a[3*N+1:4*N]))
     return log(sa2)
+end
+
+
+function colFFTwshift(plan::N, F::Array{T,2}) where {T<:Number,N<:FFTW.cFFTWPlan}
+
+    #   Performs a columnwise FFT along with two shifts when computing the Laguerre coefficients
+    #   of a vector valued function "weeks.func".
+    #
+    #   plan is a predetermined transform plan of the columns of F.
+    #
+    #   Samples of each vector element of "w.func" are stored in the columns of the
+    #   array F.
+
+    return AbstractFFTs.fftshift(plan*AbstractFFTs.fftshift(F))
 end

--- a/test/weeks_test.jl
+++ b/test/weeks_test.jl
@@ -59,3 +59,21 @@ end
 let Fc = Weeks(Fcomplex, 1024, datatype=Complex),  trange = range(0.0, stop=30.0, length=1000)
     @test isapprox(Fc.(trange), fcomplex.(trange), atol=0.001)
 end
+
+
+### Complex Vector
+Nr = collect(1:64)
+function fcomplex(t)
+    α = complex(-0.3,6.0)
+    return Nr .*exp(α*t)
+end
+
+function Fcomplex(s::Complex{Float64})::Vector{Complex{Float64}}
+    # Laplace domain
+    α = complex(-0.3,6.0)
+    return Nr ./(s-α)
+end
+
+let Ft = Weeks(Fcomplex,512,10.0,1.0,datatype=Complex)
+    @test isapprox(Ft(0.1), fcomplex(0.1),atol=1.0E-8)
+end


### PR DESCRIPTION
(I'm quite new to the whole package development process, so any feedback would be appreciated.)

I've modified existing methods in `weeks.jl` to evaluate the ILT of vector valued functions. This avoids repeated function evaluations when sampling the function (before the FFT).
It might be a good idea to make a seperate method, since scalar functions now output a vector of
`length = 1`.

Currently, calling `w.(t::AbstractArray)` isn't optimized and it outputs a vector of incorrectly nested vectors. Apparently, the length of the vector-function has to be an integer power of 2, otherwise the ordering of the output will be off (probably due to the call to `fftshift`).

I've added a test case which is similar to the complex one. It only evaluates `w(t)`, for a single value of `t`.

I haven't tried it yet, but this method could be generalized any array valued functions, so long that the function samples `FF` are stored along the first dimension (plans for the FFT would then be always be along the "columns"). 