### PR TITLE
Adding internals for array functions

### DIFF
--- a/src/weeks.jl
+++ b/src/weeks.jl
@@ -263,7 +263,7 @@ function _arrcoeff(F,N,sig,b)
     FF = [FF1 * (b + imaginary_unit * y1) for (FF1,y1) in zip(FF0,y)]
     FFTranspose = Array{Complex{Float64},ndims(Feval)+1}(undef,(length(y),size(Feval)...))
     # Collect coeffs along first dimension (columns)
-    permutedims!(FFTranspose,cat(FF...;dims=(ndims(Feval)+1)),(range(ndims(Feval)+1,stop=1,step=-1)))
+    permutedims!(FFTranspose,cat(FF...;dims=(ndims(Feval)+1)),[ndims(Feval)+1,1:ndims(Feval)...])
     # Plan FFT for coeffs
     FFp = FFTW.plan_fft!(FFTranspose,1,flags=FFTW.MEASURE)
     a = colFFTwshift(FFp,FFTranspose) ./ (2 * N)

--- a/src/weeks.jl
+++ b/src/weeks.jl
@@ -32,8 +32,8 @@ end
 _get_coefficients(w::Weeks{T}) where T <: Number =  _get_coefficients(w.func, w.Nterms, w.sigma, w.b, T)
 _set_coefficients(w::Weeks) = (w.coefficients = _get_coefficients(w))
 
-_get_array_coefficients(w::Weeks{T}) where T <: Number = _get_coefficients(w.func, w.Nterms, w.sigma, w.b, T)
-_set_array_coefficients(w::Weeks) = (w.coefficients = _get_coefficients(w))
+_get_array_coefficients(w::Weeks{T}) where T <: Number = _get_array_coefficients(w.func, w.Nterms, w.sigma, w.b, T)
+#_set_array_coefficients(w::Weeks) = (w.coefficients = _get_coefficients(w))
 
 const weeks_default_num_terms = 64
 

--- a/src/weeks.jl
+++ b/src/weeks.jl
@@ -23,8 +23,17 @@ function _get_coefficients(func, Nterms, sigma, b, ::Type{T}) where T <:Number
     return a0[Nterms+1:2*Nterms]
 end
 
+function _get_array_coefficients(func, Nterms, sigma, b, ::Type{T}) where T <:Number
+    a0 = _arrcoeff(func,Nterms, sigma, b, T)
+    return selectdim(a0,1,Nterms+1:2*Nterms)
+end
+
+
 _get_coefficients(w::Weeks{T}) where T <: Number =  _get_coefficients(w.func, w.Nterms, w.sigma, w.b, T)
 _set_coefficients(w::Weeks) = (w.coefficients = _get_coefficients(w))
+
+_get_array_coefficients(w::Weeks{T}) where T <: Number = _get_coefficients(w.func, w.Nterms, w.sigma, w.b, T)
+_set_array_coefficients(w::Weeks) = (w.coefficients = _get_coefficients(w))
 
 const weeks_default_num_terms = 64
 
@@ -237,6 +246,9 @@ end
 function colFFTwshift(plan::N, F::AbstractArray) where {N<:FFTW.cFFTWPlan}
     return AbstractFFTs.fftshift(plan*AbstractFFTs.fftshift(F,1),1)
 end
+
+_arrcoeff(F, N, sig, b, ::Type{T}) where T <: Real = real(_arrcoeff(F, N, sig, b))
+_arrcoeff(F, N, sig, b, ::Type{T}) where T <: Complex = _arrcoeff(F, N, sig, b)
 
 # Array version of _wcoeff, can output scalar version as well.
 function _arrcoeff(F,N,sig,b)

--- a/test/arrayweeks_test.jl
+++ b/test/arrayweeks_test.jl
@@ -47,3 +47,24 @@ let arr = try InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Compl
         laguerreeval = reshape(mapslices(i -> InverseLaplace._laguerre(i,1.0),arr,dims=(1)),(2,2))
         @test isapprox(laguerreeval, [1 2; 3 4] .* InverseLaplace._laguerre(scal,1.0), atol = 1E-15)
 end
+
+
+
+# Test the ILT calculation for arrays and compare with the scalar Weeks method
+let
+    # Weeks parameters
+        σ = 1.0
+        b = 0.5
+        t = 1.0
+
+    # Evaluating ILT for array valued function
+    coef = InverseLaplace._get_array_coefficients(arrFcomplex,4,σ,b,Complex)
+    lag = reshape(mapslices(i -> InverseLaplace._laguerre(i,2 * b * t),coef,dims=(1)),(2,2))
+    inverse = lag .* exp((σ - b) * t)
+
+    # Evaluating ILT for scalar function, then multiplying by an array
+    Ft = Weeks(Fcomplex,4,σ,b,datatype=Complex)
+    Ft_array_eval = [1 2;3 4]  .* Ft(1.0)
+
+    @test isapprox(Ft_array_eval , inverse, atol=1E-15)
+end

--- a/test/arrayweeks_test.jl
+++ b/test/arrayweeks_test.jl
@@ -1,0 +1,33 @@
+
+function arrFcomplex(s)
+    # Laplace domain
+    α = complex(-0.3, 6.0)
+    return [1 2;3 4] ./ (s - α)
+end
+
+function Fcomplex(s)
+    # Laplace domain
+    α = complex(-0.3, 6.0)
+    return 1 / (s - α)
+end
+
+# Test scalar-functionality of arrcoeff, Fcomplex=(s-a)⁻¹
+let arr = try InverseLaplace._arrcoeff(Fcomplex,4,1.0,1.0);
+    InverseLaplace._arrcoeff(Fcomplex,4,1.0,1.0)
+    catch
+        InverseLaplace._arrcoeff(Fcomplex,4,1.0,1.0)
+    end, scal = InverseLaplace._wcoeff(Fcomplex,4,1.0,1.0)
+
+        @test arr == scal
+end
+
+let arr = try InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0);
+    InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0)
+    catch
+        InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0)
+    end, scal = InverseLaplace._wcoeff(Fcomplex,4,1.0,1.0)
+        @test arr[:,1,1] == scal
+        @test arr[:,2,1] == 2 .* arr[:,1,1]
+        @test isapprox(arr[:,1,2] , 3 .* arr[:,1,1], atol=1E-15)
+        @test arr[:,2,2] == 4 .* arr[:,1,1]
+end

--- a/test/arrayweeks_test.jl
+++ b/test/arrayweeks_test.jl
@@ -28,8 +28,8 @@ let arr = try InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0);
         InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0)
     end, scal = InverseLaplace._wcoeff(Fcomplex,4,1.0,1.0)
         @test arr[:,1,1] == scal
-        @test arr[:,2,1] == 2 .* arr[:,1,1]
-        @test isapprox(arr[:,1,2] , 3 .* arr[:,1,1], atol=1E-15)
+        @test arr[:,1,2] == 2 .* arr[:,1,1]
+        @test isapprox(arr[:,2,1] , 3 .* arr[:,1,1], atol=1E-15)
         @test arr[:,2,2] == 4 .* arr[:,1,1]
 end
 
@@ -40,17 +40,10 @@ let arr = try InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Compl
         InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Complex)
     end, scal = InverseLaplace._get_coefficients(Fcomplex,4,1.0,1.0,Complex)
         @test arr[:,1,1] == scal
-        @test arr[:,2,1] == 2 .* arr[:,1,1]
-        @test isapprox(arr[:,1,2] , 3 .* arr[:,1,1], atol=1E-15)
-        @test arr[:,2,2] == 4 .* arr[:,1,1]
+        @test arr[:,1,2] == 2 .* scal
+        @test isapprox(arr[:,2,1] , 3 .* scal, atol=1E-15)
+        @test arr[:,2,2] == 4 .* scal
 
         laguerreeval = reshape(mapslices(i -> InverseLaplace._laguerre(i,1.0),arr,dims=(1)),(2,2))
-        @test laguerreeval[1,1] == InverseLaplace._laguerre(scal,1.0)
-        @test laguerreeval[2,1] == 2 * InverseLaplace._laguerre(scal,1.0)
-        @test isapprox(laguerreeval[1,2], 3 * InverseLaplace._laguerre(scal,1.0), atol=1E-15)
-        @test laguerreeval[2,2] == 4 * InverseLaplace._laguerre(scal,1.0)
-
-        # Noticed that 2 and 3 have changed places.
-        # Check _arrcoeff or colFFTwshift?
-        @test_broken isapprox(laguerreeval, [1 2; 3 4] .* InverseLaplace._laguerre(scal,1.0), atol = 1E-15)
+        @test isapprox(laguerreeval, [1 2; 3 4] .* InverseLaplace._laguerre(scal,1.0), atol = 1E-15)
 end

--- a/test/arrayweeks_test.jl
+++ b/test/arrayweeks_test.jl
@@ -21,11 +21,24 @@ let arr = try InverseLaplace._arrcoeff(Fcomplex,4,1.0,1.0);
         @test arr == scal
 end
 
+# Test for ordering of array valued coefficients (along first dimension)
 let arr = try InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0);
     InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0)
     catch
         InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0)
     end, scal = InverseLaplace._wcoeff(Fcomplex,4,1.0,1.0)
+        @test arr[:,1,1] == scal
+        @test arr[:,2,1] == 2 .* arr[:,1,1]
+        @test isapprox(arr[:,1,2] , 3 .* arr[:,1,1], atol=1E-15)
+        @test arr[:,2,2] == 4 .* arr[:,1,1]
+end
+
+# Test _get_coefficients for array functions
+let arr = try InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Complex);
+    InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Complex)
+    catch
+        InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Complex)
+    end, scal = InverseLaplace._get_coefficients(Fcomplex,4,1.0,1.0,Complex)
         @test arr[:,1,1] == scal
         @test arr[:,2,1] == 2 .* arr[:,1,1]
         @test isapprox(arr[:,1,2] , 3 .* arr[:,1,1], atol=1E-15)

--- a/test/arrayweeks_test.jl
+++ b/test/arrayweeks_test.jl
@@ -33,7 +33,7 @@ let arr = try InverseLaplace._arrcoeff(arrFcomplex,4,1.0,1.0);
         @test arr[:,2,2] == 4 .* arr[:,1,1]
 end
 
-# Test _get_coefficients for array functions
+# Compare _get_coefficients and _laguerre for array functions and scalar functions
 let arr = try InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Complex);
     InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Complex)
     catch
@@ -43,4 +43,14 @@ let arr = try InverseLaplace._get_array_coefficients(arrFcomplex,4,1.0,1.0,Compl
         @test arr[:,2,1] == 2 .* arr[:,1,1]
         @test isapprox(arr[:,1,2] , 3 .* arr[:,1,1], atol=1E-15)
         @test arr[:,2,2] == 4 .* arr[:,1,1]
+
+        laguerreeval = reshape(mapslices(i -> InverseLaplace._laguerre(i,1.0),arr,dims=(1)),(2,2))
+        @test laguerreeval[1,1] == InverseLaplace._laguerre(scal,1.0)
+        @test laguerreeval[2,1] == 2 * InverseLaplace._laguerre(scal,1.0)
+        @test isapprox(laguerreeval[1,2], 3 * InverseLaplace._laguerre(scal,1.0), atol=1E-15)
+        @test laguerreeval[2,2] == 4 * InverseLaplace._laguerre(scal,1.0)
+
+        # Noticed that 2 and 3 have changed places.
+        # Check _arrcoeff or colFFTwshift?
+        @test_broken isapprox(laguerreeval, [1 2; 3 4] .* InverseLaplace._laguerre(scal,1.0), atol = 1E-15)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ import InverseLaplace: talbot, gwr
 using Test
 
 include("weeks_test.jl")
+include("arrayweeks_test.jl")
 include("interface_test.jl")
 
 #### plain function interface

--- a/test/weeks_test.jl
+++ b/test/weeks_test.jl
@@ -56,6 +56,6 @@ function fcomplex(t)
     return exp(α * t)
 end
 
-let Fc = Weeks(Fcomplex, 1024, datatype=Complex),  trange = range(0.0, stop=30.0, length=1000)
-    @test isapprox(Fc.(trange), fcomplex.(trange), atol=0.001)
+let Fc = Weeks(Fcomplex, 256, 1.0, 10.0, datatype=Complex),  trange = range(0.0, stop=15.0, length=5)
+    @test isapprox(Fc.(trange), fcomplex.(trange), atol=0.0001)
 end


### PR DESCRIPTION
My previous pull request broke existing functionality, so I decided to restart my work and add internal functions for arrays.

If the function is an N-dimensional array, its Laguerre-coefficients are stored in an (N+1)-dimensional array. The FFT is performed along the first dimension of that coefficient array when calculating the Laguerre-series.

In the test file specific to array-valued functions ([`test/arrayweeks_test.jl`](https://github.com/elisno/InverseLaplace.jl/blob/005feac865b132d52c9181597cd7884dbd25350c/test/arrayweeks_test.jl)), calls to the internal functions seem to require two attempts (the first one usually outputs arrays of zeros). I haven't bothered to work on that, but I'll create a separate issue for that soon.
