### PR TITLE
Gaver-Stehfest method "Post-Widder"

### DIFF
--- a/src/InverseLaplace.jl
+++ b/src/InverseLaplace.jl
@@ -11,6 +11,7 @@ export Weeks, WeeksErr, setparameters
 export Talbot, GWR, ILT
 export TransformPair, ILtPair, abserr, iltpair_power
 export ilt, talbot, gwr
+export postwid, _PWcoeffs
 
 abstract type AbstractILt end
 
@@ -154,5 +155,6 @@ include("fixed_talbot.jl")
 include("gwr.jl")
 include("weeks.jl")
 include("pairtest.jl")
+include("postwidder.jl")
 
 end # module

--- a/src/postwidder.jl
+++ b/src/postwidder.jl
@@ -17,8 +17,9 @@
 
 
 #= Compute Post-Widder coefficients Vk for N terms. Also referred to as Salzer summation weights or Stehfest coefficients.
-Only depend on the approximation order (N) and the precision. M must be even. Coefficients get very large in magnitude and oscillate rapidly.
-Must be careful to avoid catastrophic cancellation. 
+Only depend on the approximation order (N) and the precision. M must be even but can be precomputed and used only once. 
+Coefficients get very large in magnitude and oscillate rapidly. Must be careful to avoid catastrophic cancellation for lower precision. 
+For  N < 18 double precision is usually ok but less accurate, utilizng defualt BigFloat precision and N = 36 usually provides sufficient accuracy.
 =#
 function _PWcoeffs(N)
     if isodd(N)
@@ -26,7 +27,7 @@ function _PWcoeffs(N)
         @warn "N must be even... increment N += 1"
     end
     v = zeros(BigFloat, N)
-    aux = zero(BigFloat)
+    aux = zero(eltype(v))
     for k in 1:N
         for j in floor(Int, (k + 1)/2):minimum(Int, [k, N/2])
             aux = big(j)^(N/2)*factorial(big(2*j))

--- a/src/postwidder.jl
+++ b/src/postwidder.jl
@@ -1,0 +1,82 @@
+# Gaver-Stehfest method "Post-Widder"
+
+# 1.
+# Stehfest, Harald.
+# Algorithm 368: Numerical inversion of Laplace transforms [D5].
+# Communications of the ACM 13.1 (1970): 47-49.
+
+# 2.
+# Kuhlman, Kristopher L. 
+# Review of inverse Laplace transform algorithms for Laplace-space numerical approaches.
+# Numerical Algorithms 63.2 (2013): 339-355.
+
+# 3. 
+# Al-Shuaibi, Abdulaziz. 
+# Inversion of the laplace transform via post—widder formula.
+# Integral Transforms and Special Functions 11.3 (2001): 225-232.
+
+
+# Compute Post-Widder coefficients Vk for N terms. 
+function _PWcoeffs(N)
+    v = zeros(BigFloat, N)
+    aux = big(0.0)
+    for k in 1:N
+        for j in floor(Int, (k + 1)/2):minimum(Int, [k, N/2])
+            aux = big(j)^(N/2)*factorial(big(2*j))
+            aux /= factorial(big(N/2 - j))*factorial(big(j))*factorial(big(j-1))
+            aux /= factorial(big(k - j))*factorial(big(2*j - k))
+            v[k] += aux
+        end
+        v[k] *= (-1)^(k + N/2) 
+    end
+    return v
+end
+"""
+    postwid(func::Function, t::AbstractFloat, v::Array{AbstractFloat,1}=_PWcoeffs(N))
+
+Evaluate the inverse Laplace transform of `func` at the point `t` using the Gaver-Stehfest "Post-Widder" algorithm. 
+Vk coefficients only depend on the number of expansion terms so can be computed once. N (which must be even) defaults to 18. 
+In general the accuracy in double precision is poor, so arbitrary precision is used throughout. 
+
+Increasing precision should be accompanied by an increase in the number of coefficients used.
+Increasing precision without increasing number of coefficients will not yield better accuracy. The inverse is generally true as well.
+
+This method is not robust to oscillating F(t) and must be smooth. 
+# Example
+
+```jldoctest
+julia> setprecision(53); InverseLaplace.postwid(s -> 1/(s + 1), 2.0)
+0.1353356835639731
+```
+"""
+function postwid(func::Function, t::AbstractFloat; v = _PWcoeffs(18))
+    N = length(v)
+    a = zero(eltype(v))
+    for k in 1:N
+        bk = convert(eltype(v), k)
+        a += v[k]*func(bk*log(2)/t)
+    end
+    return a*log(2)/t
+end
+"""
+    postwid(func::Function, t::AbstractArray, v::Array{AbstractFloat,1}=_PWcoeffs(N))
+
+Evaluate the inverse Laplace transform of `func` over an array of `t` using the Gaver-Stehfest "Post-Widder" algorithm. 
+Computes coefficients once and calculates f(t) across available threads.
+# Example
+
+```jldoctest
+julia> setprecision(53); postwid(s -> 1/(s + 1), 2.0:4.0)
+ 0.1353356835639731
+ 0.049786688998390505
+ 0.01831327193414956
+```
+"""
+function postwid(f::Function, t::AbstractArray; v = _PWcoeffs(18))
+    N = length(v)
+    a = zeros(eltype(v), length(t))
+    Threads.@threads for ind in eachindex(t)
+        a[ind] = postwid(f, t[ind], v = v)
+    end
+    return a
+end

--- a/src/postwidder.jl
+++ b/src/postwidder.jl
@@ -6,19 +6,19 @@
 # Communications of the ACM 13.1 (1970): 47-49.
 
 # 2.
-# Kuhlman, Kristopher L. 
+# Kuhlman, Kristopher L.
 # Review of inverse Laplace transform algorithms for Laplace-space numerical approaches.
 # Numerical Algorithms 63.2 (2013): 339-355.
 
-# 3. 
-# Al-Shuaibi, Abdulaziz. 
+# 3.
+# Al-Shuaibi, Abdulaziz.
 # Inversion of the laplace transform via post—widder formula.
 # Integral Transforms and Special Functions 11.3 (2001): 225-232.
 
 
 #= Compute Post-Widder coefficients Vk for N terms. Also referred to as Salzer summation weights or Stehfest coefficients.
-Only depend on the approximation order (N) and the precision. M must be even but can be precomputed and used only once. 
-Coefficients get very large in magnitude and oscillate rapidly. Must be careful to avoid catastrophic cancellation for lower precision. 
+Only depend on the approximation order (N) and the precision. M must be even but can be precomputed and used only once.
+Coefficients get very large in magnitude and oscillate rapidly. Must be careful to avoid catastrophic cancellation for lower precision.
 For  N < 18 double precision is usually ok but less accurate, utilizng defualt BigFloat precision and N = 36 usually provides sufficient accuracy.
 =#
 function _PWcoeffs(N::Integer)
@@ -29,7 +29,7 @@ function _PWcoeffs(N::Integer)
     v = zeros(BigFloat, N)
     aux = zero(eltype(v))
     for k in 1:N
-        for j in floor(Int, div(k + 1, 2)):minimum(Int, [k, div(N, 2)])
+        for j in fld(k + 1, 2):minimum(Int, [k, div(N, 2)])
             aux = big(j)^(div(N, 2)) * factorial(big(2 * j))
             aux /= factorial(big(div(N, 2) - j)) * factorial(big(j)) * factorial(big(j - 1))
             aux /= factorial(big(k - j)) * factorial(big(2 * j - k))
@@ -42,14 +42,14 @@ end
 """
     postwid(func::Function, t::AbstractFloat, v::Array{AbstractFloat,1}=_PWcoeffs(N))
 
-Evaluate the inverse Laplace transform of `func` at the point `t` using the Gaver-Stehfest "Post-Widder" algorithm. 
-Vk coefficients only depend on the number of expansion terms so can be computed once. N (which must be even) defaults to 18. 
-In general the accuracy in double precision is poor, so arbitrary precision is used throughout. 
+Evaluate the inverse Laplace transform of `func` at the point `t` using the Gaver-Stehfest "Post-Widder" algorithm.
+Vk coefficients only depend on the number of expansion terms so can be computed once. N (which must be even) defaults to 18.
+In general the accuracy in double precision is poor, so arbitrary precision is used throughout.
 
 Increasing precision should be accompanied by an increase in the number of coefficients used.
 Increasing precision without increasing number of coefficients will not yield better accuracy. The inverse is generally true as well.
 
-This method is not robust to oscillating F(t) and must be smooth. 
+This method is not robust to oscillating F(t) and must be smooth.
 # Example
 
 ```jldoctest
@@ -69,7 +69,7 @@ end
 """
     postwid(func::Function, t::AbstractArray, v::Array{AbstractFloat,1}=_PWcoeffs(N))
 
-Evaluate the inverse Laplace transform of `func` over an array of `t` using the Gaver-Stehfest "Post-Widder" algorithm. 
+Evaluate the inverse Laplace transform of `func` over an array of `t` using the Gaver-Stehfest "Post-Widder" algorithm.
 Computes coefficients once and calculates f(t) across available threads.
 # Example
 

--- a/src/postwidder.jl
+++ b/src/postwidder.jl
@@ -16,10 +16,17 @@
 # Integral Transforms and Special Functions 11.3 (2001): 225-232.
 
 
-# Compute Post-Widder coefficients Vk for N terms. 
+#= Compute Post-Widder coefficients Vk for N terms. Also referred to as Salzer summation weights or Stehfest coefficients.
+Only depend on the approximation order (N) and the precision. M must be even. Coefficients get very large in magnitude and oscillate rapidly.
+Must be careful to avoid catastrophic cancellation. 
+=#
 function _PWcoeffs(N)
+    if isodd(N)
+        N += 1
+        @warn "N must be even... increment N += 1"
+    end
     v = zeros(BigFloat, N)
-    aux = big(0.0)
+    aux = zero(BigFloat)
     for k in 1:N
         for j in floor(Int, (k + 1)/2):minimum(Int, [k, N/2])
             aux = big(j)^(N/2)*factorial(big(2*j))

--- a/src/postwidder.jl
+++ b/src/postwidder.jl
@@ -21,7 +21,7 @@ Only depend on the approximation order (N) and the precision. M must be even but
 Coefficients get very large in magnitude and oscillate rapidly. Must be careful to avoid catastrophic cancellation for lower precision. 
 For  N < 18 double precision is usually ok but less accurate, utilizng defualt BigFloat precision and N = 36 usually provides sufficient accuracy.
 =#
-function _PWcoeffs(N)
+function _PWcoeffs(N::Integer)
     if isodd(N)
         N += 1
         @warn "N must be even... increment N += 1"
@@ -29,13 +29,13 @@ function _PWcoeffs(N)
     v = zeros(BigFloat, N)
     aux = zero(eltype(v))
     for k in 1:N
-        for j in floor(Int, (k + 1)/2):minimum(Int, [k, N/2])
-            aux = big(j)^(N/2)*factorial(big(2*j))
-            aux /= factorial(big(N/2 - j))*factorial(big(j))*factorial(big(j-1))
-            aux /= factorial(big(k - j))*factorial(big(2*j - k))
+        for j in floor(Int, div(k + 1, 2)):minimum(Int, [k, div(N, 2)])
+            aux = big(j)^(div(N, 2)) * factorial(big(2 * j))
+            aux /= factorial(big(div(N, 2) - j)) * factorial(big(j)) * factorial(big(j - 1))
+            aux /= factorial(big(k - j)) * factorial(big(2 * j - k))
             v[k] += aux
         end
-        v[k] *= (-1)^(k + N/2) 
+        v[k] *= (-1)^(k + div(N, 2))
     end
     return v
 end
@@ -62,9 +62,9 @@ function postwid(func::Function, t::AbstractFloat; v = _PWcoeffs(18))
     a = zero(eltype(v))
     for k in 1:N
         bk = convert(eltype(v), k)
-        a += v[k]*func(bk*log(2)/t)
+        a += v[k] * func(bk * log(convert(eltype(a), 2)) / t)
     end
-    return a*log(2)/t
+    return a * log(convert(eltype(a), 2)) / t
 end
 """
     postwid(func::Function, t::AbstractArray, v::Array{AbstractFloat,1}=_PWcoeffs(N))

--- a/test/postwidder_tests.jl
+++ b/test/postwidder_tests.jl
@@ -1,0 +1,87 @@
+module postwidderTests
+
+using Test
+using InverseLaplace: postwid, _PWcoeffs
+
+
+# Compare against results reported in Algorithm 368: Numerical inversion of Laplace transforms [D5].
+
+#### F(s) = 1/sqrt(s), f(t) = 1/sqrt(π*t)
+
+# test for single time point
+setprecision(53)
+t = 1.0
+@test isapprox(postwid(s -> 1/sqrt(s), t, v = _PWcoeffs(18)), 1/sqrt(pi*t), rtol = 1e-4)
+t = 5.0
+@test isapprox(postwid(s -> 1/sqrt(s), t, v = _PWcoeffs(18)), 1/sqrt(pi*t), rtol = 1e-4)
+
+setprecision(128)
+t = 1.0
+@test isapprox(postwid(s -> 1/sqrt(s), t, v = _PWcoeffs(36)), 1/sqrt(pi*t), rtol = 1e-12)
+t = 5.0
+@test isapprox(postwid(s -> 1/sqrt(s), t, v = _PWcoeffs(36)), 1/sqrt(pi*t), rtol = 1e-12)
+
+# test across t array
+t = 1.0:10.0
+
+setprecision(53)
+@test isapprox(postwid(s -> 1/sqrt(s), t, v = _PWcoeffs(18)), 1 ./ sqrt.(pi.*t), rtol = 1e-4)
+
+setprecision(128)
+@test isapprox(postwid(s -> 1/sqrt(s), t, v = _PWcoeffs(36)), 1 ./ sqrt.(pi.*t), rtol = 1e-12)
+
+
+#### F(s) = 1/s^4, f(t) = t^3 / 6
+
+# test for single time point
+setprecision(53)
+t = 1.0
+@test isapprox(postwid(s -> 1/s^4, t, v = _PWcoeffs(18)), t^3/6, rtol = 1e-4)
+t = 5.0
+@test isapprox(postwid(s -> 1/s^4, t, v = _PWcoeffs(18)), t^3/6, rtol = 1e-4)
+
+setprecision(128)
+t = 1.0
+@test isapprox(postwid(s -> 1/s^4, t, v = _PWcoeffs(36)), t^3/6, rtol = 1e-12)
+t = 5.0
+@test isapprox(postwid(s -> 1/s^4, t, v = _PWcoeffs(36)), t^3/6, rtol = 1e-12)
+
+# test across t array
+t = 1.0:10.0
+
+setprecision(53)
+@test isapprox(postwid(s -> 1/s^4, t, v = _PWcoeffs(18)), t.^3 ./6, rtol = 1e-4)
+
+setprecision(128)
+@test isapprox(postwid(s -> 1/s^4, t, v = _PWcoeffs(36)), t.^3 ./6, rtol = 1e-12)
+
+
+#### F(s) = 1/(s+1), f(t) = exp(-t)
+## for larger t you need a higher amount of coeffs depending on accuracy
+
+# test for single time point
+setprecision(53)
+t = 1.0
+@test isapprox(postwid(s -> 1/(s+1), t, v = _PWcoeffs(18)), exp(-t), rtol = 1e-4)
+t = 5.0
+@test isapprox(postwid(s -> 1/(s+1), t, v = _PWcoeffs(18)), exp(-t), rtol = 1e-3)
+
+setprecision(128)
+t = 1.0
+@test isapprox(postwid(s -> 1/(s+1), t, v = _PWcoeffs(36)), exp(-t), rtol = 1e-12)
+t = 5.0
+@test isapprox(postwid(s -> 1/(s+1), t, v = _PWcoeffs(36)), exp(-t), rtol = 1e-8)
+
+# test across t array
+t = 1.0:10.0
+
+setprecision(53)
+@test isapprox(postwid(s -> 1/(s+1), t, v = _PWcoeffs(18)), exp.(-t), rtol = 1e-3)
+
+setprecision(128)
+@test isapprox(postwid(s -> 1/(s+1), t, v = _PWcoeffs(36)), exp.(-t), rtol = 1e-8)
+
+
+
+
+end # module

--- a/test/postwidder_tests.jl
+++ b/test/postwidder_tests.jl
@@ -82,6 +82,4 @@ setprecision(128)
 @test isapprox(postwid(s -> 1/(s+1), t, v = _PWcoeffs(36)), exp.(-t), rtol = 1e-8)
 
 
-
-
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,3 +56,5 @@ end
     @test typeof(talbot(s -> 1/s^3, 1//10)) == BigFloat
     @test typeof(talbot(s -> 1/s^3, 1//10, 64)) == BigFloat
 end
+
+@time @testset "postwidder" begin include("postwidder_tests.jl") end


### PR DESCRIPTION
I saw that the Gaver-Stehfest was brought up in issue #11 but it doesn't look like it has been implemented yet. The implementation is based on "Algorithm 368: Numerical inversion of Laplace transforms [D5]" by Stehfest. I put the relevant citation at the top of `postwidder.jl`. The test suite utilizes the examples given in Stehfest paper. 

To summarize changes:
- A new file in the src directory `postwidder.jl` was created that contains the algorithm
- `src/InverseLaplace.jl` was updated to include `postwidder.jl` and export `postwid`, `_PWcoeffs` functions
- tests were created in `test/postwidder_tests.jl` within its own module
- `test/runtests.jl` was changed to run the postwidder_tests module

More details on `postwidder.jl`:
- There are two functions `_PWcoeffs` and `postwid` in the algorithm.
- `_PWcoeffs` compute the Stehfest coefficients Vk for N terms. These coefficients only depend on the approximation order N and the precision. In practice, they can be precomputed and reused. 
- `postwid` calculated the inverse Laplace transform given a function, time, and Stehfest coefficients. This has two methods for AbstractFloats and AbstractArrays. 

Design decision and discussion points:
- The Stehfest coefficients get very large in magnitude and oscillate rapidly so precision is a key issue. For N > 18 double precision is not sufficient. For N < 18, the transform can be quite inaccurate depending on required accuracy. Further insight can be gained by manipulating some of the tests in `test/postwidder_tests.jl`. Relative errors less than 1e-4 are hard to obtain but significantly better accuracy can be obtained with higher precision and more coefficients. For this reason, the coefficients are coded for just BigFloat types. `postwid` computes the transform in the precision of the inputted coefficients so the coefficients could be converted to Float64 types and used if computational speed is required. (Brief side here if speed is a concern or if F(s) is very expensive this probably isn't the best method)
- Another thing is the best way to utilize the Stehfest coefficients. The way I've been using them is computing them once as `v = _PWcoeffs(18)` and then calculating the transfrom as `postwid(s -> 1/(s + 1), 2.0, v = v)` where the coefficients v are a key argument that defaults to `v = _PWcoeffs(18)` if not given. I'm not for sure the standard or design philosophy you would like to go with on something like this. 
- Something I have not really looked at is automatically determining precision to use. The defaults `setprecision()` for `BigFloats` seems to be sufficient but can be specified like I have done in the test suite.

Stress Test F(s) = 1/ (s + 1), f(t) = exp(-t) evaluated at t = 96.0:
```julia
julia> setprecision(700)
700

julia> talbot(s -> 1 / (s+1), big(96.0))
6.8725992764492895529192955046726350687734355474752530798441389851646621611267757158447100409065858434160888803422698295276643610618171568604254924959009021097545385178924492166858034017761536382166729299777034746e-40

julia> postwid(s -> 1/(s + 1), 96.0, v = _PWcoeffs(224))
2.031092662735010476519034811392861362756016239031457708521472788631749482789384498270623901727836314073847672326990540976644602955133794909552541668297827785492041748047275924975765337830907037406520176101315374e-42

## analytic
julia> exp(-96.0)
2.031092662734811e-42

### benchmarks (all done with setprecision(700))

# talbot
julia> @benchmark talbot(s -> 1 / (s+1), $big(96.0))
BenchmarkTools.Trial: 
  memory estimate:  761.78 KiB
  allocs estimate:  9668
  --------------
  minimum time:     4.405 ms (0.00% GC)
  median time:      4.512 ms (0.00% GC)
  mean time:        4.520 ms (0.42% GC)
  maximum time:     5.905 ms (20.20% GC)
  --------------
  samples:          1106
  evals/sample:     1

# Post-Widder
julia> @benchmark postwid(s -> 1/(s + 1), $96.0, v = _PWcoeffs(224))
BenchmarkTools.Trial: 
  memory estimate:  19.25 MiB
  allocs estimate:  423406
  --------------
  minimum time:     59.767 ms (0.00% GC)
  median time:      60.226 ms (0.00% GC)
  mean time:        67.837 ms (4.13% GC)
  maximum time:     79.153 ms (8.71% GC)
  --------------
  samples:          74
  evals/sample:     1

# Post-Widder with coefficients precomputed
julia> @benchmark postwid(s -> 1/(s + 1), $96.0, v = v)
BenchmarkTools.Trial: 
  memory estimate:  245.53 KiB
  allocs estimate:  3146
  --------------
  minimum time:     341.250 μs (0.00% GC)
  median time:      345.584 μs (0.00% GC)
  mean time:        352.999 μs (1.91% GC)
  maximum time:     1.635 ms (78.54% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

Anyway, this is my first pull request so any suggestions would be greatly appreciated. I also have several other implementations of inverse LT utilizing hyperbola, parabola and the improved talbot method if these are of interests. 

Best,
Michael