### PR TITLE
Update Gaver functional array allocation in gwr.jl

### DIFF
--- a/src/gwr.jl
+++ b/src/gwr.jl
@@ -48,7 +48,7 @@ function gwr(func, t, M)
             bi = convert(Dt, i)
             sm += binomial(big(n), big(i)) * (-1)^i * Fi[n + i]
         end
-        G0[n] = tau * SpecialFunctions.factorial(2 * bn) /   # FIXME: Do this more efficiently
+        G0[n+1] = tau * SpecialFunctions.factorial(2 * bn) /   # FIXME: Do this more efficiently
             (SpecialFunctions.factorial(bn) * SpecialFunctions.factorial(bn - 1)) * sm
     end
     Gm = zeros(Dt, M1 + 1)


### PR DESCRIPTION
Hi!

Just a small change: looks like the Gaver functionals are being added to the array in the wrong place, meaning f_1 is being assigned in place of f_0 etc, and f_M is ending up as zero, rather than having f_0=0. (Compare equation 4 from Abate and Valkó, Multi-precision Laplace transform inversion, 2004)

Did some testing against the 35 test functions from Cohen (Numerical methods for Laplace transform inversion, 2007) just to confirm and it generally does better after the change.
Sometimes does slightly worse, but generally this is for problems where the GWR method isn't working very well anyway (i.e. square wave, unshifted sinh, etc.) or else its only worse for a particular values of M on a given problem (since M+2 doesn't necessarily give a better approximation than M, I'm guessing).

Here are some results for $t=9.9$

<img width="246" height="470" alt="Error comparisons" src="https://github.com/user-attachments/assets/6b3b2bc4-f4d5-4842-867d-4fba87e4bd50" />


![ErrorComparisonM15](https://github.com/user-attachments/assets/fc305bc9-feae-4b3e-b27b-f5bd54451020)
(Plotting $$\frac{|error_{old}| - |error_{new}|}{|error_{old}| + |error_{new}|}$$ so that a value of 1 means the new code is doing better, conversely for -1. A value of zero means they're both doing about the same, and no value means both errors are zero.)
